### PR TITLE
Fix prune_fields index handling and add tests

### DIFF
--- a/dataset/utils.py
+++ b/dataset/utils.py
@@ -29,7 +29,14 @@ def parallel_map(sc, bucket_name, keys, map_func, context, columns):
     return results
 
 def prune_fields(record, excluded_indices):
-    for index in excluded_indices:
+    """Remove fields at the specified indices from ``record``.
+
+    ``excluded_indices`` may be in any order. Deleting items from a list by
+    index causes later indices to shift, so we delete from the highest index to
+    the lowest to ensure the correct elements are removed.
+    """
+
+    for index in sorted(excluded_indices, reverse=True):
         del record[index]
     return record
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,3 @@
+import sys, os
+# Ensure the repository root is on the Python path for imports
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,5 @@
 import unittest
-from dataset.utils import encode_array, encode_json
+from dataset.utils import encode_array, encode_json, prune_fields
 
 class TestUtils(unittest.TestCase):
 
@@ -19,6 +19,11 @@ class TestUtils(unittest.TestCase):
         self.assertEqual(encode_json([]), '"[]"')
         self.assertEqual(encode_json({"key": "value\nwith\nnewlines"}), '"{"key":"value\\nwith\\nnewlines"}"')
         self.assertEqual(encode_json({"key": 'value with "quotes"'}), '"{"key":"value with \\"quotes\\""}"')
+
+    def test_prune_fields_removes_correct_indices(self):
+        record = [0, 1, 2, 3, 4]
+        # removing indices 1 and 3 should remove the values 1 and 3
+        self.assertEqual(prune_fields(record, [1, 3]), [0, 2, 4])
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- ensure `prune_fields` removes list items from highest to lowest index to avoid shifting
- add regression test for `prune_fields`
- add `conftest.py` to make project importable in tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897dc29d9c4833292c89a0e0bcdcab6